### PR TITLE
ath79: add usb-phy-analog to reset list in qca953x.dtsi

### DIFF
--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -60,8 +60,8 @@
 				reg = <0x18030000 0x100>;
 				#phy-cells = <0>;
 
-				reset-names = "usb-phy", "usb-suspend-override";
-				resets = <&rst 4>, <&rst 3>;
+				reset-names = "usb-phy-analog", "usb-phy", "usb-suspend-override";
+				resets = <&rst 11>, <&rst 4>, <&rst 3>;
 
 				status = "disabled";
 			};


### PR DESCRIPTION
 USB of QCA9531 board cann't be initialized successfully when system startup, lsusb result as below:
 root@OpenWrt:~#lsusb
 unable to initialize libusb: -99
    
 This is because usb-phy-analog is not added to reset list.